### PR TITLE
fix(storage): infer temp file mime from filename

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,5 +86,8 @@
                 "chatluna_storage"
             ]
         }
+    },
+    "dependencies": {
+        "file-type": "16.5.4"
     }
 }

--- a/src/backends/base.ts
+++ b/src/backends/base.ts
@@ -46,6 +46,13 @@ export interface StorageBackend {
     download(key: string): Promise<Buffer>
 
     /**
+     * Download a file from storage as a readable stream.
+     * @param key File key/path
+     * @returns Readable stream of file content
+     */
+    downloadStream(key: string): NodeJS.ReadableStream
+
+    /**
      * Delete a file from storage
      * @param key File key/path
      */

--- a/src/backends/local.ts
+++ b/src/backends/local.ts
@@ -1,4 +1,4 @@
-import { createWriteStream } from 'fs'
+import { createReadStream, createWriteStream } from 'fs'
 import { join } from 'path'
 import fs from 'fs/promises'
 import { pipeline } from 'stream/promises'
@@ -41,6 +41,10 @@ export class LocalStorageBackend implements StorageBackend {
 
     async download(key: string): Promise<Buffer> {
         return fs.readFile(key)
+    }
+
+    downloadStream(key: string): NodeJS.ReadableStream {
+        return createReadStream(key)
     }
 
     async delete(key: string): Promise<void> {

--- a/src/backends/r2.ts
+++ b/src/backends/r2.ts
@@ -1,4 +1,5 @@
 import { createHmac, createHash } from 'crypto'
+import { Readable } from 'stream'
 import {
     createStreamingRequestInit,
     readStream,
@@ -163,6 +164,16 @@ export class R2StorageBackend implements StorageBackend {
         }
 
         return Buffer.from(await response.arrayBuffer())
+    }
+
+    downloadStream(key: string): NodeJS.ReadableStream {
+        const self = this
+        return Readable.from(
+            (async function* () {
+                const buf = await self.download(key)
+                yield buf
+            })()
+        )
     }
 
     async delete(key: string): Promise<void> {

--- a/src/backends/s3.ts
+++ b/src/backends/s3.ts
@@ -1,4 +1,5 @@
 import { createHmac, createHash } from 'crypto'
+import { Readable } from 'stream'
 import {
     createStreamingRequestInit,
     readStream,
@@ -154,6 +155,16 @@ export class S3StorageBackend implements StorageBackend {
         }
 
         return Buffer.from(await response.arrayBuffer())
+    }
+
+    downloadStream(key: string): NodeJS.ReadableStream {
+        const self = this
+        return Readable.from(
+            (async function* () {
+                const buf = await self.download(key)
+                yield buf
+            })()
+        )
     }
 
     async delete(key: string): Promise<void> {

--- a/src/backends/webdav.ts
+++ b/src/backends/webdav.ts
@@ -1,3 +1,4 @@
+import { Readable } from 'stream'
 import {
     createStreamingRequestInit,
     readStream,
@@ -123,6 +124,16 @@ export class WebDAVStorageBackend implements StorageBackend {
         }
 
         return Buffer.from(await response.arrayBuffer())
+    }
+
+    downloadStream(key: string): NodeJS.ReadableStream {
+        const self = this
+        return Readable.from(
+            (async function* () {
+                const buf = await self.download(key)
+                yield buf
+            })()
+        )
     }
 
     async delete(key: string): Promise<void> {

--- a/src/plugins/backend.ts
+++ b/src/plugins/backend.ts
@@ -1,7 +1,6 @@
 import { Context } from 'koishi'
 import { Config, logger } from '../index.js'
 import type {} from '../service/storage.js'
-import { getMimeTypeFromFilename } from '../utils.js'
 import type {} from '@koishijs/plugin-server'
 
 export function apply(ctx: Context, config: Config) {
@@ -14,7 +13,8 @@ export function apply(ctx: Context, config: Config) {
             const { id } = koa.params
 
             try {
-                const fileInfo = await ctx.chatluna_storage.getTempFile(id)
+                const fileInfo =
+                    await ctx.chatluna_storage.getTempFileStream(id)
 
                 if (!fileInfo) {
                     koa.status = 404
@@ -27,19 +27,16 @@ export function apply(ctx: Context, config: Config) {
                     return
                 }
 
-                const mime =
-                    fileInfo.type ||
-                    getMimeTypeFromFilename(fileInfo.name) ||
-                    'application/octet-stream'
-
-                // For local files or files without public URL, serve directly
-                koa.set('Content-Type', mime)
+                koa.set(
+                    'Content-Type',
+                    fileInfo.type || 'application/octet-stream'
+                )
                 koa.set('Content-Length', fileInfo.size.toString())
                 koa.set(
                     'Content-Disposition',
                     `inline; filename="${fileInfo.name}"`
                 )
-                koa.body = await fileInfo.data
+                koa.body = fileInfo.stream
             } catch (error) {
                 logger.error('Error serving temp file:', error)
                 koa.status = 500

--- a/src/plugins/backend.ts
+++ b/src/plugins/backend.ts
@@ -1,6 +1,7 @@
 import { Context } from 'koishi'
 import { Config, logger } from '../index.js'
 import type {} from '../service/storage.js'
+import { getMimeTypeFromFilename } from '../utils.js'
 import type {} from '@koishijs/plugin-server'
 
 export function apply(ctx: Context, config: Config) {
@@ -26,11 +27,13 @@ export function apply(ctx: Context, config: Config) {
                     return
                 }
 
+                const mime =
+                    fileInfo.type ||
+                    getMimeTypeFromFilename(fileInfo.name) ||
+                    'application/octet-stream'
+
                 // For local files or files without public URL, serve directly
-                koa.set(
-                    'Content-Type',
-                    fileInfo.type || 'application/octet-stream'
-                )
+                koa.set('Content-Type', mime)
                 koa.set('Content-Length', fileInfo.size.toString())
                 koa.set(
                     'Content-Disposition',

--- a/src/service/storage.ts
+++ b/src/service/storage.ts
@@ -337,9 +337,12 @@ export class ChatLunaStorageService extends Service {
             randomName =
                 (randomName.split('.')?.[0] ?? randomName) + '.' + imageType
         }
+        const imageMime = imageType
+            ? getMimeTypeFromFilename(`file.${imageType}`)
+            : undefined
         const fileType =
             mimeType ??
-            getImageType(buffer) ??
+            imageMime ??
             getMimeTypeFromFilename(randomName)
 
         // Upload to storage backend
@@ -437,13 +440,15 @@ export class ChatLunaStorageService extends Service {
             }
 
             const randomName = randomFileName(filename)
+            const fileType =
+                meta.mimeType ?? getMimeTypeFromFilename(randomName)
             const result = await this.storageBackend.uploadStream(
                 createReadStream(tempPath),
                 randomName,
                 {
                     size,
                     hash: digest,
-                    mimeType: meta.mimeType
+                    mimeType: fileType
                 }
             )
 
@@ -459,7 +464,7 @@ export class ChatLunaStorageService extends Service {
                 id: randomName.split('.')[0],
                 path: result.key,
                 name: randomName,
-                type: meta.mimeType,
+                type: fileType,
                 expireTime,
                 size,
                 accessTime: currentTime,

--- a/src/service/storage.ts
+++ b/src/service/storage.ts
@@ -7,12 +7,7 @@ import { pipeline } from 'stream/promises'
 import { Context, Service, Time } from 'koishi'
 import { Config, logger } from '..'
 import { TempFileInfo, TempFileInfoWithData } from '../types'
-import {
-    computeHash,
-    getImageType,
-    getMimeTypeFromFilename,
-    randomFileName
-} from '../utils'
+import { computeHash, detectFileType, randomFileName } from '../utils'
 import {
     StorageBackend,
     createStorageBackend,
@@ -229,6 +224,17 @@ export class ChatLunaStorageService extends Service {
         return fs.readFile(file.path)
     }
 
+    private downloadFileStream(file: TempFileInfo): NodeJS.ReadableStream {
+        const storageType = file.storageType ?? 'local'
+        if (
+            storageType !== 'local' &&
+            this.storageBackend.type === storageType
+        ) {
+            return this.storageBackend.downloadStream(file.path)
+        }
+        return createReadStream(file.path)
+    }
+
     private async removeFile(file: TempFileInfo): Promise<void> {
         try {
             await this.deleteFileFromBackend(file)
@@ -331,19 +337,13 @@ export class ChatLunaStorageService extends Service {
             }
         }
 
+        const detected = await detectFileType(buffer)
         let randomName = randomFileName(filename)
-        const imageType = getImageType(buffer, true, true)
-        if (imageType != null) {
+        if (detected) {
             randomName =
-                (randomName.split('.')?.[0] ?? randomName) + '.' + imageType
+                (randomName.split('.')[0] ?? randomName) + '.' + detected.ext
         }
-        const imageMime = imageType
-            ? getMimeTypeFromFilename(`file.${imageType}`)
-            : undefined
-        const fileType =
-            mimeType ??
-            imageMime ??
-            getMimeTypeFromFilename(randomName)
+        const fileType = mimeType ?? detected?.mime
 
         // Upload to storage backend
         const result = await this.storageBackend.upload(buffer, randomName)
@@ -440,15 +440,13 @@ export class ChatLunaStorageService extends Service {
             }
 
             const randomName = randomFileName(filename)
-            const fileType =
-                meta.mimeType ?? getMimeTypeFromFilename(randomName)
             const result = await this.storageBackend.uploadStream(
                 createReadStream(tempPath),
                 randomName,
                 {
                     size,
                     hash: digest,
-                    mimeType: fileType
+                    mimeType: meta.mimeType
                 }
             )
 
@@ -464,7 +462,7 @@ export class ChatLunaStorageService extends Service {
                 id: randomName.split('.')[0],
                 path: result.key,
                 name: randomName,
-                type: fileType,
+                type: meta.mimeType,
                 expireTime,
                 size,
                 accessTime: currentTime,
@@ -557,6 +555,49 @@ export class ChatLunaStorageService extends Service {
             await this.ctx.database.remove('chatluna_storage_temp', { id })
             this.removeFromLRU(id)
             return null
+        }
+    }
+
+    /**
+     * Get a temp file's metadata and a readable stream for its content.
+     * Use this for serving files over HTTP to avoid loading entire files into memory.
+     */
+    async getTempFileStream(
+        id: string
+    ): Promise<(TempFileInfo & { stream: NodeJS.ReadableStream; url: string }) | null> {
+        let fileInfo = await this.ctx.database.get('chatluna_storage_temp', {
+            id
+        })
+
+        if (fileInfo.length === 0) {
+            fileInfo = await this.ctx.database.get('chatluna_storage_temp', {
+                name: id
+            })
+        }
+
+        if (fileInfo.length === 0) return null
+
+        const file = fileInfo[0]
+
+        const currentTime = new Date()
+        await this.ctx.database.set(
+            'chatluna_storage_temp',
+            { id: file.id },
+            {
+                accessTime: currentTime,
+                accessCount: file.accessCount + 1
+            }
+        )
+
+        this.addToLRU(file.id)
+
+        const url = file.publicUrl ?? `${this.backendPath}/temp/${file.name}`
+        return {
+            ...file,
+            accessTime: currentTime,
+            accessCount: file.accessCount + 1,
+            stream: this.downloadFileStream(file),
+            url
         }
     }
 

--- a/src/service/storage.ts
+++ b/src/service/storage.ts
@@ -7,7 +7,12 @@ import { pipeline } from 'stream/promises'
 import { Context, Service, Time } from 'koishi'
 import { Config, logger } from '..'
 import { TempFileInfo, TempFileInfoWithData } from '../types'
-import { computeHash, getImageType, randomFileName } from '../utils'
+import {
+    computeHash,
+    getImageType,
+    getMimeTypeFromFilename,
+    randomFileName
+} from '../utils'
 import {
     StorageBackend,
     createStorageBackend,
@@ -326,14 +331,16 @@ export class ChatLunaStorageService extends Service {
             }
         }
 
-        const imageType = getImageType(buffer, true, true)
-        const fileType = mimeType ?? getImageType(buffer)
-
         let randomName = randomFileName(filename)
+        const imageType = getImageType(buffer, true, true)
         if (imageType != null) {
             randomName =
                 (randomName.split('.')?.[0] ?? randomName) + '.' + imageType
         }
+        const fileType =
+            mimeType ??
+            getImageType(buffer) ??
+            getMimeTypeFromFilename(randomName)
 
         // Upload to storage backend
         const result = await this.storageBackend.upload(buffer, randomName)

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,11 @@
 import { createHash } from 'crypto'
 
 const FILE_MIME_TYPES: Record<string, string> = {
+    png: 'image/png',
+    jpg: 'image/jpeg',
+    jpeg: 'image/jpeg',
+    gif: 'image/gif',
+    webp: 'image/webp',
     mp4: 'video/mp4',
     webm: 'video/webm',
     mov: 'video/quicktime',
@@ -89,5 +94,7 @@ export function randomFileName(fileName: string): string {
 }
 
 export function getMimeTypeFromFilename(fileName: string): string | undefined {
-    return FILE_MIME_TYPES[fileName.toLowerCase().split('.').pop() ?? '']
+    const index = fileName.lastIndexOf('.')
+    if (index < 0) return undefined
+    return FILE_MIME_TYPES[fileName.slice(index + 1).toLowerCase()]
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,15 @@
 import { createHash } from 'crypto'
 
+const FILE_MIME_TYPES: Record<string, string> = {
+    mp4: 'video/mp4',
+    webm: 'video/webm',
+    mov: 'video/quicktime',
+    mp3: 'audio/mpeg',
+    m4a: 'audio/mp4',
+    wav: 'audio/wav',
+    ogg: 'audio/ogg'
+}
+
 /**
  * Computes the SHA-256 hash of the given buffer and returns it as a hex string.
  * SHA-256 is cryptographically modern and collision-resistant.
@@ -76,4 +86,8 @@ export function randomFileName(fileName: string): string {
 
     const additionalRandom = Math.random().toString(36).substring(2, 10)
     return `${timestamp}_${additionalRandom}${extension}`
+}
+
+export function getMimeTypeFromFilename(fileName: string): string | undefined {
+    return FILE_MIME_TYPES[fileName.toLowerCase().split('.').pop() ?? '']
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,19 +1,5 @@
 import { createHash } from 'crypto'
-
-const FILE_MIME_TYPES: Record<string, string> = {
-    png: 'image/png',
-    jpg: 'image/jpeg',
-    jpeg: 'image/jpeg',
-    gif: 'image/gif',
-    webp: 'image/webp',
-    mp4: 'video/mp4',
-    webm: 'video/webm',
-    mov: 'video/quicktime',
-    mp3: 'audio/mpeg',
-    m4a: 'audio/mp4',
-    wav: 'audio/wav',
-    ogg: 'audio/ogg'
-}
+import FileType from 'file-type'
 
 /**
  * Computes the SHA-256 hash of the given buffer and returns it as a hex string.
@@ -23,65 +9,17 @@ export function computeHash(buffer: Buffer): string {
     return createHash('sha256').update(buffer).digest('hex')
 }
 
-export function getImageType(
-    buffer: Buffer,
-    pure: boolean = false,
-    checkIsImage: boolean = true
-): string {
-    if (buffer.length < 12) {
-        return checkIsImage ? undefined : pure ? 'jpg' : 'image/jpeg'
-    }
-
-    // PNG: 89 50 4E 47 0D 0A 1A 0A
-    if (
-        buffer[0] === 0x89 &&
-        buffer[1] === 0x50 &&
-        buffer[2] === 0x4e &&
-        buffer[3] === 0x47 &&
-        buffer[4] === 0x0d &&
-        buffer[5] === 0x0a &&
-        buffer[6] === 0x1a &&
-        buffer[7] === 0x0a
-    ) {
-        return pure ? 'png' : 'image/png'
-    }
-
-    // JPEG: FF D8 FF
-    if (buffer[0] === 0xff && buffer[1] === 0xd8 && buffer[2] === 0xff) {
-        return pure ? 'jpg' : 'image/jpeg'
-    }
-
-    // GIF: 47 49 46 38 (GIF8)
-    if (
-        buffer[0] === 0x47 &&
-        buffer[1] === 0x49 &&
-        buffer[2] === 0x46 &&
-        buffer[3] === 0x38
-    ) {
-        return pure ? 'gif' : 'image/gif'
-    }
-
-    // WebP: 52 49 46 46 ... 57 45 42 50 (RIFF....WEBP)
-    if (
-        buffer[0] === 0x52 &&
-        buffer[1] === 0x49 &&
-        buffer[2] === 0x46 &&
-        buffer[3] === 0x46 &&
-        buffer[8] === 0x57 &&
-        buffer[9] === 0x45 &&
-        buffer[10] === 0x42 &&
-        buffer[11] === 0x50
-    ) {
-        return pure ? 'webp' : 'image/webp'
-    }
-
-    if (checkIsImage) {
-        return undefined
-    }
-
-    return pure ? 'jpg' : 'image/jpeg'
+/**
+ * Detect MIME type and extension from a buffer using magic bytes.
+ * Returns `{ mime, ext }` or `undefined` if unrecognized.
+ */
+export async function detectFileType(
+    buffer: Buffer
+): Promise<{ mime: string; ext: string } | undefined> {
+    const result = await FileType.fromBuffer(buffer)
+    if (!result) return undefined
+    return { mime: result.mime, ext: result.ext }
 }
-
 
 export function randomFileName(fileName: string): string {
     const extension = fileName.includes('.')
@@ -91,10 +29,4 @@ export function randomFileName(fileName: string): string {
 
     const additionalRandom = Math.random().toString(36).substring(2, 10)
     return `${timestamp}_${additionalRandom}${extension}`
-}
-
-export function getMimeTypeFromFilename(fileName: string): string | undefined {
-    const index = fileName.lastIndexOf('.')
-    if (index < 0) return undefined
-    return FILE_MIME_TYPES[fileName.slice(index + 1).toLowerCase()]
 }


### PR DESCRIPTION
## 摘要

- 为临时文件增加基于文件名后缀的 MIME 兜底推断。
- 创建临时文件时，在调用方未传入 MIME 且不是可识别图片时，写入常见音视频 MIME。
- 服务已有临时文件时，如果数据库记录缺少 `type`，按文件名返回正确 `Content-Type`。

## 验证

- `yarn build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Temp files can now be streamed directly when downloaded, reducing memory use and enabling faster delivery.

* **Improvements**
  * File type detection for uploads and served files is improved for more accurate Content-Type headers.
  * Storage backends gained stream-based downloads for more reliable and efficient file retrieval.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ChatLunaLab/chatluna-storage-service/pull/2?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->